### PR TITLE
fix(types): Correct property name in AnimeListStatus for API compatibility

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -66,7 +66,7 @@ export interface Genre {
 export interface AnimeListStatus {
     status?: 'watching' | 'completed' | 'on_hold' | 'dropped' | 'plan_to_watch';
     score?: number;
-    num_episodes_watched?: number;
+    num_watched_episodes?: number;
     is_rewatching?: boolean;
     start_date?: Date;
     finish_date?: Date;


### PR DESCRIPTION
This PR corrects a property name in the `AnimeListStatus` interface to align with the MAL API.

This is a fix for a bug that occurs when updating a user's anime list. Sending an update request with the old property name (num_episodes_watched) causes the MAL API to reject the request with the following error: 

```json
{
    "message": "This form should not contain extra fields.",
    "error": "bad_request"
}
```

Updated `num_episodes_watched` to `num_watched_episodes` to match what the MyAnimeList API actually expects.

